### PR TITLE
Update p8.css. Fixing circled-number-container class.

### DIFF
--- a/GanjooRazor/wwwroot/css/p8.css
+++ b/GanjooRazor/wwwroot/css/p8.css
@@ -1410,9 +1410,13 @@ audio {
 }
 
 .circled-number-container {
-    width: 100%;
-    display: inline-table;
+    width: 100%;    
     direction: ltr;
+    display: inline-flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    row-gap: 2px;
+    column-gap: 5px;
 }
 
 .circled-number, .circled-number-diff, .navbar-help-button {


### PR DESCRIPTION
After changing the circled-number class's display property to inline-grid there was bug in showing circled numbers that didn't contain text (for example the one that points to the map section in the first page.). This commit fixes the bug.