### PR TITLE
Use gold highlight color and reduce mobile poem/tooltip font sizes

### DIFF
--- a/GanjooRazor/wwwroot/css/p8.css
+++ b/GanjooRazor/wwwroot/css/p8.css
@@ -547,7 +547,7 @@ a img {
 
 .hilite {
     color: var(--ink-black);
-    background-color: var(--lapis-hover)
+    background-color: var(--gold)
 }
 
 .hilite1 {
@@ -1232,7 +1232,7 @@ pagination-controls {
 
         .b p {
             text-align: center;
-            font-size: 1.4em;
+            font-size: 1.1em;
         }
 
         .b > div:not(.bnum) {
@@ -1241,7 +1241,7 @@ pagination-controls {
         }
 
     .tooltip {
-        font-size: 1.4em;
+        font-size: 1.1em;
     }
 
     .bnum, .n .bnum, .l .bnum {


### PR DESCRIPTION
## Summary
- `.hilite` background: `--lapis-hover` → `--gold`
- Mobile (`.b p` and `.tooltip`) font-size: `1.4em` → `1.1em`

## Screenshots

### Mobile view

<img width="395" height="850" alt="image" src="https://github.com/user-attachments/assets/ba1dcb9e-9676-4afb-a8aa-7bad5208c09e" />

### Search result

<img width="1012" height="365" alt="image" src="https://github.com/user-attachments/assets/133a9ae2-3b5b-431e-a452-04203c4a9060" />

### Test plan
- [ ] Verify highlighted search matches show gold background
- [ ] Verify poem text and tooltips render at the smaller size on mobile viewport

