### PR TITLE
Tooltip and poem title styling fixes

### DIFF
--- a/GanjooRazor/wwwroot/css/p8.css
+++ b/GanjooRazor/wwwroot/css/p8.css
@@ -1263,7 +1263,8 @@ pagination-controls {
     }
 
         .tooltip a:hover {
-            background: var(--card-inner);
+            background: rgba(255, 255, 255, 0.12);
+            color: white;
         }
 
     .tooltip::before {
@@ -1271,7 +1272,7 @@ pagination-controls {
         display: block;
         border-left: 0.5em solid transparent;
         border-right: 0.5em solid transparent;
-        border-bottom: 0.5em solid var(--card-inner);
+        border-bottom: 0.5em solid rgba(14, 17, 17, 0.9);
         position: absolute;
         top: 0;
         margin-top: -0.5em;
@@ -2038,11 +2039,15 @@ audio {
     -webkit-text-fill-color: var(--lapis);
     font-family: 'IranNastaliq', serif;
     font-size: 2.1rem;
-    line-height: 2;
+    line-height: 2.4;
     display: inline-block;
-    padding: 0 20px 4px;
+    padding: 5px 20px;
     border-bottom: 2px solid var(--brand);
     text-shadow: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    max-width: 575px;
 }
 
 .poets-poet {

--- a/GanjooRazor/wwwroot/js/vaabd.js
+++ b/GanjooRazor/wwwroot/js/vaabd.js
@@ -54,7 +54,7 @@ var $close = $('<a href="#" id="vaabx">غیرفعال شود</a>').css({
     justifyContent: 'center',
     alignItems: 'center',
     textAlign: 'center',
-    borderTop: '1px solid rgba(255,255,255,0.2)', // Visual separator
+    borderTop: '1px solid #c9a050', // Visual separator
 });
 
 // Tooltip container styling


### PR DESCRIPTION
## Summary
- Refine `#page-hierarchy h2 a` styling: increase line-height, adjust padding, add font-smoothing and legibility hints, and cap width.
- Fix tooltip text color on hover.
- Use a consistent dark tooltip look in both light and dark modes, with a subtle hover highlight.

## Screenshots

### Before:

<img width="832" height="452" alt="image" src="https://github.com/user-attachments/assets/91d5a98c-ab0a-42eb-abf2-65a57da16f12" />

### After:

<img width="832" height="533" alt="image" src="https://github.com/user-attachments/assets/292dbbdc-bc5a-4f6f-bd89-4bfac0640865" />

### Tooltip:

<img width="168" height="381" alt="image" src="https://github.com/user-attachments/assets/7a2ac55c-4fb5-401d-a814-8b1530c03f93" />
